### PR TITLE
Wrong address notation

### DIFF
--- a/modules/nw-multus-ipam-object.adoc
+++ b/modules/nw-multus-ipam-object.adoc
@@ -120,7 +120,7 @@ such as `example-host`, during a DNS lookup query.
     "type": "static",
       "addresses": [
         {
-          "address": "191.168.1.7"
+          "address": "191.168.1.7/24"
         }
       ]
   }

--- a/modules/nw-multus-ipvlan-object.adoc
+++ b/modules/nw-multus-ipvlan-object.adoc
@@ -65,7 +65,7 @@ The following example configures an additional network named `ipvlan-net`:
     "type": "static",
     "addresses": [
        {
-         "address": "192.168.10.10"
+         "address": "192.168.10.10/24"
        }
     ]
   }


### PR DESCRIPTION
*Missing required network prefix*

Version(s):
  * PR applies to all versions after a specific version: 4.6+

Issue:
POD creation fails due to this:

`Warning  FailedCreatePodSandBox  3s    kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create pod network sandbox k8s_multus-training-6f8cbbbf74-vn7v2_multus-training_b397a304-a920-4cd6-97c1-203f0ca2dc33_0(1a6516c279b60da692fb0dd3fc7206b49bf8904748f0fa3e68ab3530f01d7b71): error adding pod multus-training_multus-training-6f8cbbbf74-vn7v2 to CNI network "multus-cni-network": plugin type="multus" name="multus-cni-network" failed (add): [multus-training/multus-training-6f8cbbbf74-vn7v2/b397a304-a920-4cd6-97c1-203f0ca2dc33:work-network]: error adding container to network "work-network": the 'address' field is expected to be in CIDR notation, got: '192.168.10.10'`

Link to docs preview:
https://docs.openshift.com/container-platform/4.6/networking/multiple_networks/configuring-additional-network.html#nw-multus-ipvlan-config-example_configuring-additional-network
https://docs.openshift.com/container-platform/4.7/networking/multiple_networks/configuring-additional-network.html#nw-multus-ipvlan-config-example_configuring-additional-network
https://docs.openshift.com/container-platform/4.8/networking/multiple_networks/configuring-additional-network.html#nw-multus-ipvlan-config-example_configuring-additional-network
https://docs.openshift.com/container-platform/4.9/networking/multiple_networks/configuring-additional-network.html#nw-multus-ipvlan-config-example_configuring-additional-network
https://docs.openshift.com/container-platform/4.10/networking/multiple_networks/configuring-additional-network.html#nw-multus-ipvlan-config-example_configuring-additional-network
https://docs.openshift.com/container-platform/4.11/networking/multiple_networks/configuring-additional-network.html#nw-multus-ipvlan-config-example_configuring-additional-network